### PR TITLE
Fixed typo in "Functions and Function Calls" lerp(...) example.

### DIFF
--- a/ispc.html
+++ b/ispc.html
@@ -2690,7 +2690,7 @@ visibility and capabilities.  As in C/C++, functions have global visibility
 by default.  If a function is declared with a <tt class="docutils literal">static</tt> qualifier, then it
 is only visible in the file in which it was declared.</p>
 <pre class="literal-block">
-static void lerp(float t, float a, float b) {
+static float lerp(float t, float a, float b) {
     return (1.-t)*a + t*b;
 }
 </pre>


### PR DESCRIPTION
Hi,

Fixed typo in lerp(...) example. Return type should be float, not void.

Before:
![image](https://cloud.githubusercontent.com/assets/1844966/26754214/98b35232-4876-11e7-84fa-d655462494c0.png)

After:
![image](https://cloud.githubusercontent.com/assets/1844966/26754217/ac61d90c-4876-11e7-81fc-97990a87d1c0.png)

-Colin