### PR TITLE
Update InPar link to IEEE's

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -103,7 +103,7 @@
             on <tt>ispc</tt>, <a href="https://github.com/downloads/ispc/ispc/ispc_inpar_2012.pdf">ispc:
             A SPMD Compiler for High-Performance CPU Programming</a>, by
             Matt Pharr and William R. Mark, has been accepted to
-            the <a href="http://innovativeparallel.org/">InPar 2012</a>
+            the <a href="https://ieeexplore.ieee.org/xpl/conhome/6330715/proceeding">InPar 2012</a>
             conference. This paper describes a number of the design
             features and key characteristics of the <tt>ispc</tt>
             implementation.</p>


### PR DESCRIPTION
Pervious domain was taken by an online casino.

![image](https://user-images.githubusercontent.com/8112071/175881591-a257c8b5-175b-4104-9cb0-483b3ad51b65.png)
