### PR TITLE
Update links to main archives

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -115,11 +115,9 @@
             Here are latest ISPC binaries corresponding to main branch (based on LLVM 18.1.8):
           </p>
           <ul>
-            <li><a href="https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-windows.zip?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DVisual%20Studio%202019%2C%20LLVM_VERSION%3Dlatest">Windows (64 bit)
-            ispc binary</a></li>
-			<li><a href="https://ci.appveyor.com/api/projects/ispc/ispc/artifacts/build%2Fispc-trunk-linux.tar.gz?job=Environment%3A%20APPVEYOR_BUILD_WORKER_IMAGE%3DUbuntu2204%2C%20LLVM_VERSION%3Dlatest">Linux (64 bit)
-            ispc binary</a></li>
-            </ul>
+            <li><a href="https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-windows.zip">Windows (64 bit) ispc binary</a></li>
+	    <li><a href="https://github.com/ispc/ispc/releases/download/trunk-artifacts/ispc-trunk-linux.tar.gz">Linux (64 bit) ispc binary</a></li>
+          </ul>
           <p>
             Here is LLVM 3.5 based binary with experimental NVPTX support:
             </p>


### PR DESCRIPTION
Artifacts have moved after https://github.com/ispc/ispc/pull/3118 to GitHub releases.